### PR TITLE
Added functions for retrieving all info for refs, branches, and tags for repo

### DIFF
--- a/github.js
+++ b/github.js
@@ -193,14 +193,71 @@
         _request("DELETE", repoPath + "/git/refs/"+ref, options, cb);
       };
 
-      // List all branches of a repository
+      // Get all raw ref info of a repository
+      // -------
+
+      this.refs = function(cb, refType, namesOnly) {
+        var refPath = refType || "/git/refs";
+        _request("GET", repoPath + refPath, null, function(err, heads) {
+          if (err) return cb(err);
+          if (namesOnly) {
+            if (refPath.match(/^\/git\/refs/)) {
+              return cb(null, _.map(heads, function(head) { return _.last(head.ref.split('/')); }));;
+            } else if (heads[0]["heads"]) {
+              return cb(null, _.map(heads, function(head) { return heads.name }));;
+            }
+          }
+          cb(null, heads);
+        });
+      };
+
+      // Get all ref branch info of a repository
+      // -------
+
+      this.refBranches = function(cb) {
+        this.refs(cb, "/git/refs/heads");
+      };
+
+      // Get all ref tag info of a repository
+      // -------
+
+      this.refTags = function(cb) {
+        this.refs(cb, "/git/refs/tags");
+      };
+
+      // List all ref names of a repository
+      // -------
+
+      this.listRefs = function(cb) {
+        this.refs(cb, null, true);
+      };
+
+      // List all branch names of a repository
       // -------
 
       this.listBranches = function(cb) {
-        _request("GET", repoPath + "/git/refs/heads", null, function(err, heads) {
-          if (err) return cb(err);
-          cb(null, _.map(heads, function(head) { return _.last(head.ref.split('/')); }));
-        });
+        this.refs(cb, "/git/refs/heads", true);
+      };
+
+      // List all tag names of a repository
+      // -------
+
+      this.listTags = function(cb) {
+        this.refs(cb, "/git/refs/tags", true);
+      };
+
+      // Get all branches of a repository
+      // -------
+
+      this.branches = function(cb) {
+        this.refs(cb, "/branches", true);
+      };
+
+      // Get all tags of a repository
+      // -------
+
+      this.tags = function(cb) {
+        this.refs(cb, "/tags", true);
       };
 
       // Retrieve the contents of a blob


### PR DESCRIPTION
I started using this recently with jspkg.com. I needed to be able to grab info for both branches and tags for a given github repo. This github.js currently only allows you to fetch a list of branch names. However, there's no reason you couldn't also fetch tag names or any other ref (including github "pulls") using basically the same function.

Also, sometimes you need more than just a list of names. And Github will actually give you the sha, url, and much more in the response. So I abstracted a couple functions, so you can retrieve all this info, but so that `listBranches` still just returns an array of names for backwards compatibility.

To summarize this pull request...

Setup repo object:
```js
var repo = github.getRepo(username, reponame);
```

Existing `listBranches` function:
```js
repo.listBranches(function(err, branches) {});
```
New functions:
```js
// List array of ref objects, returning additional ref info, like sha
// (also, listBranches and all the other following functions, now just delegate to this function internally)
repo.refs(function(err, refs) {}); 

// Array of branch objects, including additional info
repo.refBranches(function(err, branches) {}); 

// Array of tag objects, including additional info
repo.refTags(function(err, tags) {}); 

// List names of all refs (branches, tags, and pulls), similar to existing listBranches function
repo.listRefs(function(err, refs) {}); 

// List names of all tags
repo.listTags(function(err, tags) {}); 

// List names of all tags
repo.listTags(function(err, tags) {}); 

// Array of proper branch objects 
repo.branches(function(err, tags) {}); 

// Array of proper tag objects 
repo.tags(function(err, tags) {}); 
```

I should probably explain the last two functions, which say "proper branch" and "proper tag" objects. What I mean is that, the `refBranches` and `refTags` were made to be consistent with the existing `listBranches` function, which calls Github's "...:repo/git/refs/[:branches|:tags]" URL.

While they technically work, this isn't how they recommend querying their API for branches and tags. They recommend that you [get tags](http://developer.github.com/v3/repos/#list-tags) using the "...:repo/tags" endpoint, and [get branches](http://developer.github.com/v3/repos/#list-branches) using the "...:repo/branches" endpoint.

In testing, I found that the two endpoints actually respond with different sets of data. For example when you use the "refs"-based endpoint, it does return a SHA, but it's the SHA of the actual branch or tag object in git, which isn't incredibly useful. Typically when you retrieve the branch or tag, what you really mean is to fetch the commit to which that branch/tag points to. When you use the direct branch and tag endpoints recommended in Github's API docs, it will actually give you the SHA of the associated commit.

I didn't want to take out any existing functionality or assume I knew the motivation for why github.js has the branches API implemented that way, so I figured I'd just abstract the API call itself such that it's easy to use either one.

Let me know if you have any questions. This is now in production for jspkg.com and working well.