### PR TITLE
added error callbacks to remove and move

### DIFF
--- a/github.js
+++ b/github.js
@@ -252,18 +252,18 @@
         _request("DELETE", repoPath + "/git/refs/"+ref, options, cb);
       };
 
-      // Create a repo  
+      // Create a repo
       // -------
 
       this.createRepo = function(options, cb) {
         _request("POST", "/user/repos", options, cb);
       };
 
-      // Delete a repo  
-      // --------  
+      // Delete a repo
+      // --------
 
-      this.deleteRepo = function(cb) {  
-        _request("DELETE", repoPath, options, cb);  
+      this.deleteRepo = function(cb) {
+        _request("DELETE", repoPath, options, cb);
       };
 
       // List all tags of a repository
@@ -450,9 +450,9 @@
         _request("POST", repoPath + "/forks", null, cb);
       };
 
-      // Branch repository  
-      // --------  
- 
+      // Branch repository
+      // --------
+
       this.branch = function(oldBranch,newBranch,cb) {
         if(arguments.length === 2 && typeof arguments[1] === "function") {
           cb = newBranch;
@@ -535,7 +535,9 @@
             });
 
             that.postTree(newTree, function(err, rootTree) {
+              if (err) return cb(err);
               that.commit(latestCommit, rootTree, 'Deleted '+path , function(err, commit) {
+                if (err) return cb(err);
                 that.updateHead(branch, commit, function(err) {
                   cb(err);
                 });
@@ -558,7 +560,9 @@
             });
 
             that.postTree(tree, function(err, rootTree) {
+              if (err) return cb(err);
               that.commit(latestCommit, rootTree, 'Deleted '+path , function(err, commit) {
+                if (err) return cb(err);
                 that.updateHead(branch, commit, function(err) {
                   cb(err);
                 });


### PR DESCRIPTION
the repo.remove and repo.move functions were missing cb(err) safeties in the operational callbacks