### PR TITLE
Use /:path instead of ?path=:path to get contents

### DIFF
--- a/github.js
+++ b/github.js
@@ -497,7 +497,7 @@
       // --------
 
       this.contents = function(ref, path, cb) {
-        _request("GET", repoPath + "/contents/"+path, { ref: ref }, cb);
+        _request("GET", repoPath + "/contents" + (path ? "/" + path : ""), { ref: ref }, cb);
       };
 
       // Fork repository


### PR DESCRIPTION
Passing `path` in the query string does not seem to work anymore with the Github API (I'm admittedly guilty of not seeking to know why). The [API documentation](http://developer.github.com/v3/repos/contents/) says to use:

    GET /repos/:owner/:repo/contents/:path

which is what this patch does (and it works ;-)).