### PR TITLE
Fix the contents function on the repository API.

### DIFF
--- a/github.js
+++ b/github.js
@@ -440,7 +440,7 @@
       // --------
 
       this.contents = function(branch, path, cb, sync) {
-        return _request("GET", repoPath + "/contents?ref=" + branch + (path ? "&path=" + path : ""), null, cb, 'raw', sync);
+        return _request("GET", repoPath + "/contents/" + path + "?ref=" + branch, null, cb, 'raw', sync);
       };
 
       // Fork repository


### PR DESCRIPTION
It appears that Github either changed their way of querying files
or directory or the bug was always there but say you want to do :

repo.contents(branch, "MYFILE", function(err, contents) {}, false);

it currently doesn't work and list only the root directory of the
repository. Changing slightly the way Github.js query the contents
make things works correctly as expected.