### PR TITLE
content API update and some other features

### DIFF
--- a/github.js
+++ b/github.js
@@ -645,9 +645,10 @@
           }
           _request("GET", url, null, cb);
       };
-    };
 
-    this.req=_request;
+      this.req=_request;
+
+    };
 
     // Gists API
     // =======

--- a/github.js
+++ b/github.js
@@ -445,9 +445,17 @@
       // --------
 
       this.contents = function(branch, path, cb, sync, datatype) {
-	if(!datatype)datatype='raw';
+	if(!datatype)datatype='raw';// use 'json' if you want to get sha of content as well, it's need for update contents
         return _request("GET", repoPath + "/contents/" + (path ? path : "") + "?ref=" + branch, null, cb, datatype, sync);
       };
+
+      // Update contents
+      // --------
+
+      this.contents_update = function(branch, path, message, content, previous_sha, cb, sync) {
+        return _request("PUT", repoPath + "/contents/" + (path ? path : "") + "?ref=" + branch,
+                 { message:message, content:Base64.encode(content), sha:previous_sha }, cb, null, sync);
+      }
 
       // Fork repository
       // -------

--- a/github.js
+++ b/github.js
@@ -647,6 +647,8 @@
       };
     };
 
+    this.req=_request;
+
     // Gists API
     // =======
 

--- a/github.js
+++ b/github.js
@@ -33,28 +33,28 @@
     //
     // I'm not proud of this and neither should you be if you were responsible for the XMLHttpRequest spec.
 
-    function _request(method, path, data, cb, raw, sync) {
+    function _request(method, path, data, cb, datatype, sync) {
       function getURL() {
         var url = path.indexOf('//') >= 0 ? path : API_URL + path;
         return url + ((/\?/).test(url) ? "&" : "?") + (new Date()).getTime();
       }
 
       var xhr = new XMLHttpRequest();
-      if (!raw) {xhr.dataType = "json";}
+      if (!datatype)datatype="json";
 
       xhr.open(method, getURL(), !sync);
       if (!sync) {
         xhr.onreadystatechange = function () {
           if (this.readyState == 4) {
             if (this.status >= 200 && this.status < 300 || this.status === 304 || this.status === 0) {
-              cb(null, raw ? this.responseText : this.responseText ? JSON.parse(this.responseText) : true, this);
+              cb(null, datatype ? this.responseText : this.responseText ? JSON.parse(this.responseText) : true, this);
             } else {
               cb({path: path, request: this, error: this.status});
             }
           }
         }
       };
-      xhr.setRequestHeader('Accept','application/vnd.github.raw+json');
+      xhr.setRequestHeader('Accept','application/vnd.github.'+datatype);
       xhr.setRequestHeader('Content-Type','application/json;charset=UTF-8');
       if ((options.token) || (options.username && options.password)) {
            xhr.setRequestHeader('Authorization', options.token

--- a/github.js
+++ b/github.js
@@ -444,8 +444,9 @@
       // Get contents
       // --------
 
-      this.contents = function(branch, path, cb, sync) {
-        return _request("GET", repoPath + "/contents?ref=" + branch + (path ? "&path=" + path : ""), null, cb, 'raw', sync);
+      this.contents = function(branch, path, cb, sync, datatype) {
+	if(!datatype)datatype='raw';
+        return _request("GET", repoPath + "/contents?ref=" + branch + (path ? "&path=" + path : ""), null, cb, datatype, sync);
       };
 
       // Fork repository

--- a/github.js
+++ b/github.js
@@ -46,7 +46,7 @@
       if (!sync) {
         xhr.onreadystatechange = function () {
           if (this.readyState == 4) {
-            if (this.status >= 200 && this.status < 300 || this.status === 304) {
+            if (this.status >= 200 && this.status < 300 || this.status === 304 || this.status === 0) {
               cb(null, raw ? this.responseText : this.responseText ? JSON.parse(this.responseText) : true, this);
             } else {
               cb({path: path, request: this, error: this.status});

--- a/github.js
+++ b/github.js
@@ -612,6 +612,7 @@
       // List commits on a repository. Takes an object of optional paramaters:
       // sha: SHA or branch to start listing commits from
       // path: Only commits containing this file path will be returned
+      // per_page: number of commits to list
       // since: ISO 8601 date - only commits after this date will be returned
       // until: ISO 8601 date - only commits before this date will be returned
       // -------
@@ -625,6 +626,9 @@
           }
           if (options.path) {
               params.push("path=" + encodeURIComponent(options.path));
+          }
+          if (options.per_page) {
+              params.push("per_page="+ encodeURIComponent(options.per_page));
           }
           if (options.since) {
               var since = options.since;

--- a/github.js
+++ b/github.js
@@ -47,7 +47,7 @@
         xhr.onreadystatechange = function () {
           if (this.readyState == 4) {
             if (this.status >= 200 && this.status < 300 || this.status === 304 || this.status === 0) {
-              cb(null, datatype ? this.responseText : this.responseText ? JSON.parse(this.responseText) : true, this);
+              cb(null, /^(?!json)/.test(datatype) ? this.responseText : this.responseText ? JSON.parse(this.responseText) : true, this);
             } else {
               cb({path: path, request: this, error: this.status});
             }
@@ -446,7 +446,7 @@
 
       this.contents = function(branch, path, cb, sync, datatype) {
 	if(!datatype)datatype='raw';
-        return _request("GET", repoPath + "/contents?ref=" + branch + (path ? "&path=" + path : ""), null, cb, datatype, sync);
+        return _request("GET", repoPath + "/contents/" + (path ? path : "") + "?ref=" + branch, null, cb, datatype, sync);
       };
 
       // Fork repository


### PR DESCRIPTION
Instead of using read/write, the content API should be used unless the data is more than 1MB, because the number of http requests get reduced from 3 to just 1, and allows multi-user commits which tracks the document SHA (prevents update with a old SHA).

A few changes to allow 4 things:
1) fix for issue #101 
getting Content(branch, path, cb, sync, 'json') will get a json with file obj sha, which is closer to what http://developer.github.com/v3/repos/contents/#get-contents is describing, with option 'json' will give the same behaviour as before, getting the file raw content

2) added a repo.req function to allow access to request, which is useful if anyone wants to make custom API calls

3) allow request status==0 which is returned from XHR request made from a locally loaded page

4) getCommits should use pagination