### PR TITLE
Adds optional "force" parameter to method "write"

### DIFF
--- a/github.js
+++ b/github.js
@@ -428,8 +428,8 @@
       // Update the reference of your head to point to the new commit SHA
       // -------
 
-      this.updateHead = function(head, commit, cb) {
-        _request("PATCH", repoPath + "/git/refs/heads/" + head, { "sha": commit }, function(err, res) {
+      this.updateHead = function(head, commit, cb, force) {
+        _request("PATCH", repoPath + "/git/refs/heads/" + head, { "sha": commit, "force":force }, function(err, res) {
           cb(err);
         });
       };
@@ -593,7 +593,7 @@
       // Write file contents to a given branch and path
       // -------
 
-      this.write = function(branch, path, content, message, cb) {
+      this.write = function(branch, path, content, message, cb, force) {
         updateTree(branch, function(err, latestCommit) {
           if (err) return cb(err);
           that.postBlob(content, function(err, blob) {
@@ -602,7 +602,7 @@
               if (err) return cb(err);
               that.commit(latestCommit, tree, message, function(err, commit) {
                 if (err) return cb(err);
-                that.updateHead(branch, commit, cb);
+                that.updateHead(branch, commit, cb, force);
               });
             });
           });


### PR DESCRIPTION
Adds optional parameter ```force``` to the ```write``` method, in compliance with Github spec

https://developer.github.com/v3/git/refs/#update-a-reference

This allows to write a non fast forward content without getting error 422, (unprocessable entity)