### PR TITLE
Use only one time parameter when quering multiple pages

### DIFF
--- a/github.js
+++ b/github.js
@@ -81,6 +81,9 @@
 
           if (next) {
             next = (/<(.*)>/.exec(next) || [])[1];
+
+            // Extract time from next link. Time is represented as 13 digit number (until 2033)
+            next = next.replace(/\&\d{13}\=/gi, '').replace(/\&\d{13}/gi, '')
           }
 
           if (!next) {


### PR DESCRIPTION
If a resource has multiple pages the script will use `next` value to retrieve next page.
Because all requests are done with datetime append to url (probably to avoid caching) `next` containes that link.

`https://api.github.com/repos/user/repo/issues/events?per_page=100&1409248439577`

Second page will be requested by appending a new datetime, so we'll have something like

`https://api.github.com/repos/user/repo/issues/events?per_page=100&page=2&1409248439577=&1409257105342`

Third page url will contain 3 datetime stamps and so on. At some point this will rise an error as browser (and server) has a limit for url size. This way it will cut some of the parameters or will simply throw an error.