### PR TITLE
add support for setting commit status on a repo

### DIFF
--- a/github.js
+++ b/github.js
@@ -661,6 +661,21 @@
           }
           _request("GET", url, null, cb);
       };
+
+      // Set Commit Status
+      // -------
+      //
+      // {
+      //   state: 'pending'|'success'|'failure'|'error' (required),
+      //   target_url: 'http://ci.example.com/user/repo/build/sha',
+      //   description: 'text of status, shown to user',
+      //   context: 'continuous-integration/my-service'
+      // }
+
+      this.setStatus = function(sha, options, cb) {
+        _request("POST", repoPath + "/statuses/" + sha, options, cb);
+      };
+
     };
 
     // Gists API


### PR DESCRIPTION
It's for external validation systems that work per-commit/pull-request, like continous integration systems.
See <https://developer.github.com/v3/repos/statuses/>.