### PR TITLE
dataType isn't an XMLHttpRequest property

### DIFF
--- a/github.js
+++ b/github.js
@@ -45,7 +45,7 @@
       }
 
       var xhr = new XMLHttpRequest();
-      if (!raw) {xhr.dataType = "json";}
+      if (!raw) {xhr.responseType = "json";}
 
       xhr.open(method, getURL(), !sync);
       if (!sync) {


### PR DESCRIPTION
I believe what you meant here was `responseType`

https://xhr.spec.whatwg.org/#the-responsetype-attribute