### PR TITLE
Change to add `sha` option at getCommit method.

### DIFF
--- a/github.js
+++ b/github.js
@@ -629,7 +629,7 @@
           var url = repoPath + "/commits";
           var params = [];
           if (options.sha) {
-              params.push("sha=" + encodeURIComponent(options.sha));
+              url += encodeURIComponent(options.sha);
           }
           if (options.path) {
               params.push("path=" + encodeURIComponent(options.path));


### PR DESCRIPTION
I tried to get commit comment and called getCommits method such as below snipets.

```coffeescript
Github = require 'github-api'
github = new Github(
  token: MY_GITHUB_TOKEN,
  auth: 'oauth'
)
commit = github.getCommits(
  sha: ONE_COMMIT_HASH,
  (err, commits) ->
    console.log(commits.length)
)
```

But got commits aren't single commits...

And I've read github API documentation and found below article!

```

GET /repos/:owner/:repo/commits/:sha
```

FYI: https://developer.github.com/v3/repos/commits/#get-a-single-commit