### PR TITLE
Make Github.Issue.list options matter

### DIFF
--- a/github.js
+++ b/github.js
@@ -755,7 +755,12 @@
       var path = "/repos/" + options.user + "/" + options.repo + "/issues";
 
       this.list = function(options, cb) {
-        _request("GET", path, options, cb);
+        var query = [];
+        for (var key in options) {
+          query.push(encodeURIComponent(key) + "=" + encodeURIComponent(options[key]));
+        }
+
+        _request("GET", path + '?' + query.join("&"), false, cb);
       };
     };
 


### PR DESCRIPTION
Issue.list takes options.  With this patch, you can use these options to filter the issues wanted, e.g.          
issues.list({"labels":"bug,ui"}, callback)


Before this patch, the options were sent as stringified data in the GET-request…