### PR TITLE
Modified Github constructor, getCommits, and getCommit. Added getComments, createComment, and updateComment.

### DIFF
--- a/github.js
+++ b/github.js
@@ -38,7 +38,7 @@
 
 
   var Github = function(options) {
-    options = options || {}
+    options = options || {};
     var API_URL = options.apiUrl || 'https://api.github.com';
 
     // HTTP Request Abstraction
@@ -683,7 +683,7 @@
       this.getCommits = function(options, cb) {
           if(arguments.length === 1 && typeof arguments[0] === "function") {
             cb = options;
-            options = {}
+            options = {};
           }
           var url = repoPath + "/commits";
           var params = [];
@@ -733,7 +733,7 @@
         }
 
         _request("GET", repoPath + commentsPath, null, cb);
-      }
+      };
 
       // Create a commit comment
       // -------
@@ -741,25 +741,25 @@
       this.createComment = function(sha, body, options, cb) {
         if(arguments.length === 3 && typeof arguments[2] === "function") {
           cb = options;
-          options = {}
+          options = {};
         }
         options.body = body;
         _request("POST", repoPath + '/commits/' + sha + '/comments', options, cb);
-      }
+      };
 
       // Update a comment
       // -------
 
       this.updateComment = function(id, body, cb) {
         _request("PATCH", repoPath + '/comments/' + id, {body: body}, cb);
-      }
+      };
 
       // Delete a comment
       // -------
 
       this.deleteComment = function(id, cb) {
-        _request("DELETE", repoPath + '/comments/' + id, null, function(){});
-      }
+        _request("DELETE", repoPath + '/comments/' + id, null, cb);
+      };
 
     };
 

--- a/github.js
+++ b/github.js
@@ -38,6 +38,7 @@
 
 
   var Github = function(options) {
+    options = options || {}
     var API_URL = options.apiUrl || 'https://api.github.com';
 
     // HTTP Request Abstraction
@@ -371,11 +372,8 @@
       // For a given file path, get the corresponding sha (blob for files, tree for dirs)
       // -------
 
-      this.getCommit = function(branch, sha, cb) {
-        _request("GET", repoPath + "/git/commits/"+sha, null, function(err, commit) {
-          if (err) return cb(err);
-          cb(null, commit);
-        });
+      this.getCommit = function(sha, cb) {
+        _request("GET", repoPath + "/commits/"+sha, null, cb);
       };
 
       // For a given file path, get the corresponding sha (blob for files, tree for dirs)
@@ -683,7 +681,10 @@
       // -------
 
       this.getCommits = function(options, cb) {
-          options = options || {};
+          if(arguments.length === 1 && typeof arguments[0] === "function") {
+            cb = options;
+            options = {}
+          }
           var url = repoPath + "/commits";
           var params = [];
           if (options.sha) {
@@ -717,6 +718,49 @@
           }
           _request("GET", url, null, cb);
       };
+
+      // List commit comments.
+      // -------
+
+      this.getComments = function(sha, cb) {
+        var commentsPath;
+        if(arguments.length === 1 && typeof arguments[0] === "function") {
+          cb = sha;
+          sha = null;
+          commentsPath = '/comments';
+        } else {
+          commentsPath = '/commits/'+sha+'/comments';
+        }
+
+        _request("GET", repoPath + commentsPath, null, cb);
+      }
+
+      // Create a commit comment
+      // -------
+
+      this.createComment = function(sha, body, options, cb) {
+        if(arguments.length === 3 && typeof arguments[2] === "function") {
+          cb = options;
+          options = {}
+        }
+        options.body = body;
+        _request("POST", repoPath + '/commits/' + sha + '/comments', options, cb);
+      }
+
+      // Update a comment
+      // -------
+
+      this.updateComment = function(id, body, cb) {
+        _request("PATCH", repoPath + '/comments/' + id, {body: body}, cb);
+      }
+
+      // Delete a comment
+      // -------
+
+      this.deleteComment = function(id, cb) {
+        _request("DELETE", repoPath + '/comments/' + id, null, function(){});
+      }
+
     };
 
     // Gists API

--- a/test/test.repo.js
+++ b/test/test.repo.js
@@ -64,11 +64,35 @@ test("Repo API", function(t) {
     });
 
     t.test('repo.getCommit', function(q) {
-        repo.getCommit('master', '20fcff9129005d14cc97b9d59b8a3d37f4fb633b', function(err, commit) {
+        repo.getCommit('20fcff9129005d14cc97b9d59b8a3d37f4fb633b', function(err, commit) {
             q.error(err, 'get commit' + err);
-            q.ok(commit.message, 'v0.10.4', 'Returned commit message.');
-            q.ok(commit.author.date, '2015-03-20T17:01:42Z', 'Got correct date.');
+            q.ok(commit.commit.message, 'v0.10.4', 'Returned commit message.');
+            q.ok(commit.commit.author.date, '2015-03-20T17:01:42Z', 'Got correct date.');
             q.end();
+        });
+    });
+
+    t.test('repo.getCommits', function(q) {
+        repo.getCommits(function(err, commits) {
+          q.error(err, 'get commits' + err);
+          q.ok(typeof commits[0].commit.message === 'string', 'Returned commits.');
+          q.end();
+        });
+    }); 
+
+    t.test('repo.getComments for a given commit', function(q) {
+        repo.getComments('750a7c677d6d78dcd453570b1e3aa02c27bd2142', function(err, comments) {
+          q.error(err, 'get comments for commit 750a7c677d6d78dcd453570b1e3aa02c27bd2142' + err);
+          q.ok(comments[0].commit_id === '750a7c677d6d78dcd453570b1e3aa02c27bd2142', 'Returned comments for 750a7c677d6d78dcd453570b1e3aa02c27bd2142.');
+          q.end();
+        });
+    });
+
+    t.test('repo.getComments for a given commit', function(q) {
+        repo.getComments(function(err, comments) {
+          q.error(err, 'get comments for entire repo' + err);
+          q.ok(typeof comments[0].body === 'string', 'Returned comments.');
+          q.end();
         });
     });
 
@@ -110,6 +134,7 @@ test('Create Repo', function(t) {
       q.end();
     });
   });
+
   clearTimeout(timeout);
   t.end();
 });


### PR DESCRIPTION
### Modifications:
- options parameter for the Github constructor is now optional, so you can instantiate with `new Github()` to access public data without specifying authorization information.
- `getCommits` was failing when only passed a callback. options parameter is now optional.
- corrected path (should not contain '/git/') and removed unnecessary argument `branch` from `getCommit(sha, cb)`.
- I removed the `branch` parameter from the `getCommit` test, because the Github API does not take a `branch` parameter.

### Added:
- Get commit comments: `getComments([sha,] cb)`
- Create a commit comment: `createComment(sha, body, [options,] cb)`
- Update a commit comment: `updateComment(id, body, cb)`
- Added tests for `getCommits` and `getComments`
