### PR TITLE
Remove moot `version` property from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,6 @@
 {
   "name": "github-api",
   "main": "github.js",
-  "version": "0.10.6",
   "homepage": "https://github.com/michael/github",
   "authors": [
     "Sergey Klimov <sergey.v.klimov@gmail.com> (http://darvin.github.com/)"


### PR DESCRIPTION
Per bower/bower.json-spec@a325da3

Also their maintainer says they probably won't ever use it: http://stackoverflow.com/questions/24844901/bowers-bower-json-file-version-property