### PR TITLE
Fixed commit on and read from a non-master branch

### DIFF
--- a/github.js
+++ b/github.js
@@ -383,7 +383,7 @@
 
       this.getSha = function(branch, path, cb) {
         if (!path || path === "") return that.getRef("heads/"+branch, cb);
-        _request("GET", repoPath + "/contents/"+path, {ref: branch}, function(err, pathContent) {
+        _request("GET", repoPath + "/contents/" + path + (branch ? "?ref=" + branch : ""), null, function(err, pathContent) {
           if (err) return cb(err);
           cb(null, pathContent.sha);
         });
@@ -596,7 +596,7 @@
       // -------
 
       this.read = function(branch, path, cb) {
-        _request("GET", repoPath + "/contents/"+encodeURI(path), {ref: branch}, function(err, obj) {
+        _request("GET", repoPath + "/contents/"+encodeURI(path) + (branch ? "?ref=" + branch : ""), null, function(err, obj) {
           if (err && err.error === 404) return cb("not found", null, null);
 
           if (err) return cb(err);

--- a/test/test.repo.js
+++ b/test/test.repo.js
@@ -104,6 +104,20 @@ test('Create Repo', function(t) {
     });
   });
 
+  t.test('repo.writeBranch', function(q) {
+    repo.branch('master', 'dev', function(err) {
+      q.error(err);
+      repo.write('dev', 'TEST.md', 'THIS IS AN UPDATED TEST', 'Updating test', function(err) {
+        q.error(err);
+        repo.read('dev', 'TEST.md', function(err, obj) {
+          t.equals('THIS IS AN UPDATED TEST', obj);
+          q.error(err);
+          q.end();
+        });
+      });
+    });
+  });
+
   t.test('repo.writeChinese', function(q) {
     repo.write('master', '中文测试.md', 'THIS IS A TEST', 'Creating test', function(err) {
       q.error(err);


### PR DESCRIPTION
There was a problem with repo.write and repo.read from a branch that was not master. The ref GET parameter was passed in the message body. I fixed it and added a test-case.