### PR TITLE
Added Repository.readme method

### DIFF
--- a/github.js
+++ b/github.js
@@ -535,6 +535,13 @@
         path = encodeURI(path);
         _request("GET", repoPath + "/contents" + (path ? "/" + path : ""), { ref: ref }, cb);
       };
+      
+      // Get README
+      // --------
+
+      this.readme = function(ref, cb) {
+        _request("GET", repoPath + "/readme", { ref: ref }, cb);
+      };      
 
       // Fork repository
       // -------


### PR DESCRIPTION
Added support for `GET /repos/:owner/:repo/readme`.
I find it useful: don't need to care about file extensions.