### PR TITLE
Fix url query string mistakes `?&`

### DIFF
--- a/github.js
+++ b/github.js
@@ -46,14 +46,14 @@
     function _request(method, path, data, cb, raw, sync) {
       function getURL() {
         var url = path.indexOf('//') >= 0 ? path : API_URL + path;
-        url += ((/\?/).test(url) ? '&' : '?');
-        // Fix #195 about XMLHttpRequest.send method and GET/HEAD request
-        if (data && typeof data === "object" && ['GET', 'HEAD'].indexOf(method) > -1) {
-          url += '&' + Object.keys(data).map(function (k) {
-            return k + '=' + data[k];
-          }).join('&');
+        url = url + ((/\?/).test(url) ? '&' : '?') + (new Date()).getTime();
+        if (method === 'GET') {
+          for(var param in data) {
+            if (data.hasOwnProperty(param))
+              url += '&' + encodeURIComponent(param) + '=' + encodeURIComponent(data[param]);
+          }
         }
-        return url + '&' + (new Date()).getTime();
+        return url;
       }
 
       var xhr = new XMLHttpRequest();
@@ -84,7 +84,7 @@
         var authorization = options.token ? 'token ' + options.token : 'Basic ' + btoa(options.username + ':' + options.password);
         xhr.setRequestHeader('Authorization', authorization);
       }
-      if (data) {
+      if (method !== 'GET' && data) {
         xhr.send(JSON.stringify(data));
       } else {
         xhr.send();

--- a/github.js
+++ b/github.js
@@ -46,8 +46,9 @@
     function _request(method, path, data, cb, raw, sync) {
       function getURL() {
         var url = path.indexOf('//') >= 0 ? path : API_URL + path;
-        url = url + ((/\?/).test(url) ? '&' : '?') + (new Date()).getTime();
-        if (method === 'GET') {
+        url += ((/\?/).test(url) ? '&' : '?');
+        url += (new Date()).getTime();
+        if (data && typeof data === 'object' && ['GET', 'HEAD'].indexOf(method) > -1) {
           for(var param in data) {
             if (data.hasOwnProperty(param))
               url += '&' + encodeURIComponent(param) + '=' + encodeURIComponent(data[param]);
@@ -84,7 +85,7 @@
         var authorization = options.token ? 'token ' + options.token : 'Basic ' + btoa(options.username + ':' + options.password);
         xhr.setRequestHeader('Authorization', authorization);
       }
-      if (method !== 'GET' && data) {
+      if (data) {
         xhr.send(JSON.stringify(data));
       } else {
         xhr.send();


### PR DESCRIPTION
1. No more `?&` in urls.
2. Now stamp precedes other params for programming convenience, but it doesn't make urls invalid.
3. `map`, `join`? ugh.. wouldn't it be easier to read `for`-loop?
4. `hasOwnProperty` added because `jshint` doesn't detect iteration through `Object.keys` and complains about it. You could fix `.jshint` as well, add `var param in Object.keys(data)` and get rid of `hasOwnProperty`.