### PR TITLE
Support author and committer info for write()

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,11 @@ repo.listBranches(function(err, branches) {});
 Store contents at a certain path, where files that don't yet exist are created on the fly.
 
 ```js
-repo.write('master', 'path/to/file', 'YOUR_NEW_CONTENTS', 'YOUR_COMMIT_MESSAGE', function(err) {});
+var options = {
+  author: {name: 'Author Name', email: 'author@example.com'},
+  committer: {name: 'Committer Name', email: 'committer@example.com'}
+}
+repo.write('master', 'path/to/file', 'YOUR_NEW_CONTENTS', 'YOUR_COMMIT_MESSAGE', options, function(err) {});
 ```
 
 Not only can you can write files, you can of course read them.

--- a/github.js
+++ b/github.js
@@ -674,13 +674,19 @@
       // Write file contents to a given branch and path
       // -------
 
-      this.write = function(branch, path, content, message, cb) {
+      this.write = function(branch, path, content, message, options, cb) {
+        if (typeof cb === 'undefined') {
+          cb = options;
+          options = {};
+        }
         that.getSha(branch, encodeURI(path), function(err, sha) {
           if (err && err.error !== 404) return cb(err);
           _request("PUT", repoPath + "/contents/" + encodeURI(path), {
             message: message,
             content: btoa(content),
             branch: branch,
+            committer: options.committer,
+            author: options.author,
             sha: sha
           }, cb);
         });

--- a/test/test.repo.js
+++ b/test/test.repo.js
@@ -58,7 +58,7 @@ test("Repo API", function(t) {
 
     t.test('repo.read', function(q) {
         repo.read('master', 'README.md', function(err, res) {
-            q.ok(res.indexOf('##Setup') !== -1, true, 'Returned REAMDE');
+            q.notEquals(res.indexOf('##Setup'), -1, 'Returned REAMDE');
             q.end();
         });
     });
@@ -66,8 +66,8 @@ test("Repo API", function(t) {
     t.test('repo.getCommit', function(q) {
         repo.getCommit('master', '20fcff9129005d14cc97b9d59b8a3d37f4fb633b', function(err, commit) {
             q.error(err, 'get commit' + err);
-            q.ok(commit.message, 'v0.10.4', 'Returned commit message.');
-            q.ok(commit.author.date, '2015-03-20T17:01:42Z', 'Got correct date.');
+            q.equals(commit.message, 'v0.10.4', 'Returned commit message.');
+            q.equals(commit.author.date, '2015-03-20T17:01:42Z', 'Got correct date.');
             q.end();
         });
     });
@@ -75,7 +75,7 @@ test("Repo API", function(t) {
     t.test('repo.getSha', function(q) {
         repo.getSha('master', '.gitignore', function(err, sha) {
             q.error(err, 'get sha error: ' + err);
-            q.ok(sha, '153216eb946aedc51f4fe88a51008b4abcac5308', 'Returned sha message.');
+            q.equals(sha, '153216eb946aedc51f4fe88a51008b4abcac5308', 'Returned sha message.');
             q.end();
         });
     });
@@ -122,6 +122,24 @@ test('Create Repo', function(t) {
           q.error(err);
           q.end();
         });
+      });
+    });
+  });
+
+  t.test('repo.writeAuthorAndCommitter', function(q) {
+    var options = {
+      author: {name: 'Author Name', email: 'author@example.com'},
+      committer: {name: 'Committer Name', email: 'committer@example.com'}
+    };
+    repo.write('dev', 'TEST.md', 'THIS IS A TEST BY AUTHOR AND COMMITTER', 'Updating', options, function(err, res) {
+      q.error(err);
+      repo.getCommit('dev', res.commit.sha, function(err, commit) {
+        q.error(err);
+        q.equals(commit.author.name, 'Author Name', 'Got correct author name.');
+        q.equals(commit.author.email, 'author@example.com', 'Got correct author email.');
+        q.equals(commit.committer.name, 'Committer Name', 'Got correct committer name.');
+        q.equals(commit.committer.email, 'committer@example.com', 'Got correct committer email.');
+        q.end();
       });
     });
   });


### PR DESCRIPTION
Hello. Github supports passing name and email for author and committer as [optional parameters](https://developer.github.com/v3/repos/contents/#optional-parameters) for `repos/contents`.
I would like to have this supported in library.