### PR TITLE
Move filters out tree nodes, rather than delete their sha

### DIFF
--- a/github.js
+++ b/github.js
@@ -655,9 +655,9 @@
         updateTree(branch, function(err, latestCommit) {
           that.getTree(latestCommit+"?recursive=true", function(err, tree) {
             // Update Tree
-            tree.forEach(function(ref) {
+            tree = tree.filter(function(ref) {
               if (ref.path === path) ref.path = newPath;
-              if (ref.type === "tree") delete ref.sha;
+              return ref.type !== "tree";
             });
 
             that.postTree(tree, function(err, rootTree) {


### PR DESCRIPTION
I was getting an error when moving files, and I came across [this issue](https://github.com/philschatz/octokit.js/issues/78) with a suggested workaround that worked for me. So I thought I'd send over a PR just incase.

However, moving files was working for me just fine before, and so the real cause of the problem is a mystery as far as I concerned. If no-one else is having the problem, then I understand if you don't feel a need to merge.