### PR TITLE
Expose request methods.

### DIFF
--- a/github.js
+++ b/github.js
@@ -43,7 +43,7 @@
     //
     // I'm not proud of this and neither should you be if you were responsible for the XMLHttpRequest spec.
 
-    function _request(method, path, data, cb, raw, sync) {
+    var _request = Github._request = function _request(method, path, data, cb, raw, sync) {
       function getURL() {
         var url = path.indexOf('//') >= 0 ? path : API_URL + path;
         url += ((/\?/).test(url) ? '&' : '?');
@@ -92,9 +92,9 @@
       if (sync) {
         return xhr.response;
       }
-    }
+    };
 
-    function _requestAllPages(path, cb) {
+    var _requestAllPages = Github._requestAllPages = function _requestAllPages(path, cb) {
       var results = [];
       (function iterate() {
         _request('GET', path, null, function(err, res, xhr) {
@@ -122,7 +122,7 @@
           }
         });
       })();
-    }
+    };
 
 
     // User API


### PR DESCRIPTION
Simple change to expose request methods. I'd like to be able to use them for unsupported API requests like to get issue comments (#194). 

I've left them underscore-prefixed, as they are ancillary and their existence or behavior may change in the future.

Especially useful is the `_requestAllPages` with `Link: rel="next"` handling. If anyone is aware of an external module that does that, then I won't need this. But otherwise, perhaps these could be extracted into an external module, or replaced by some other existing external module.
