### PR TITLE
repo: add getRepo with fullname

### DIFF
--- a/github.js
+++ b/github.js
@@ -235,9 +235,16 @@
     Github.Repository = function(options) {
       var repo = options.name;
       var user = options.user;
+      var fullname = options.fullname;
 
       var that = this;
-      var repoPath = '/repos/' + user + '/' + repo;
+      var repoPath;
+
+      if (fullname) {
+        repoPath = '/repos/' + fullname;
+      } else {
+        repoPath = '/repos/' + user + '/' + repo;
+      }
 
       var currentTree = {
         'branch': null,
@@ -842,7 +849,12 @@
     };
 
     this.getRepo = function(user, repo) {
-      return new Github.Repository({user: user, name: repo});
+      if (!repo) {
+        var fullname = user;
+        return new Github.Repository({fullname: fullname});
+      } else {
+        return new Github.Repository({user: user, name: repo});
+      }
     };
 
     this.getUser = function() {

--- a/test/test.repo.js
+++ b/test/test.repo.js
@@ -80,6 +80,15 @@ test("Repo API", function(t) {
         });
     });
 
+    t.test('getRepo(fullname)', function(q) {
+        var repo2 = github.getRepo('michael/github');
+        repo2.show(function(err, res) {
+            q.error(err, 'show repo');
+            q.equals(res.full_name, 'michael/github', 'repo name');
+            q.end();
+        });
+    });
+
     clearTimeout(timeout);
     t.end();
 


### PR DESCRIPTION
Hooks API has direct full_name to be respond, so adding a way to
initistant the repo object with full_name should be more convinent.

Now we are able to get a repo:

```js
githubapi.getRepo('nodejs/node')
```

Thanks