### PR TITLE
Allow repo.listBranches to support branch names that contains slashes

### DIFF
--- a/github.js
+++ b/github.js
@@ -12,7 +12,7 @@
 
 (function() {
   'use strict';
-  
+
   // Initial Setup
   // -------------
 
@@ -23,10 +23,10 @@
       if (typeof btoa === 'undefined') {
         btoa = require('btoa'); //jshint ignore:line
       }
-  } else { 
+  } else {
       btoa = window.btoa;
   }
-  
+
   //prefer native XMLHttpRequest always
   /* istanbul ignore if  */
   if (typeof window !== 'undefined' && typeof window.XMLHttpRequest !== 'undefined'){
@@ -106,7 +106,7 @@
 
           var links = (xhr.getResponseHeader('link') || '').split(/\s*,\s*/g),
               next = null;
-          links.forEach(function(link) { 
+          links.forEach(function(link) {
             next = /rel="next"/.test(link) ? link : next;
           });
 
@@ -259,7 +259,7 @@
         if (branch === currentTree.branch && currentTree.sha) {
           return cb(null, currentTree.sha);
         }
-        
+
         that.getRef('heads/' + branch, function(err, sha) {
           currentTree.branch = branch;
           currentTree.sha = sha;
@@ -275,7 +275,7 @@
           if (err) {
             return cb(err);
           }
-          
+
           cb(null, res.object.sha);
         });
       };
@@ -324,7 +324,7 @@
           if (err) {
             return cb(err);
           }
-          
+
           cb(null, tags);
         });
       };
@@ -366,8 +366,7 @@
         _request("GET", repoPath + "/git/refs/heads", null, function(err, heads) {
           if (err) return cb(err);
           cb(null, heads.map(function(head) {
-              var headParts = head.ref.split('/'); 
-              return headParts[headParts.length - 1];
+            return head.ref.replace(/^refs\/heads\//, '');
           }));
         });
       };


### PR DESCRIPTION
I was running into an issue with `listBranches` - we use slashes in our branch naming convention.

For example, the branch `feature/my-cool-feature` would return only `my-cool-feature`. This fixes this issue.