### PR TITLE
Add getStatuses repo endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ Retrieve all available branches (aka heads) of a repository.
 repo.listBranches(function(err, branches) {});
 ```
 
+Get list of statuses for a particular commit.
+
+```js
+repo.getStatuses(sha, function(err, statuses) {});
+```
+
 Store contents at a certain path, where files that don't yet exist are created on the fly.
 You can also provide an optional object literal, (`options` in the example below) containing information about the author and the committer.
 

--- a/github.js
+++ b/github.js
@@ -515,6 +515,18 @@
                });
          };
 
+         // Get the statuses for a particular SHA
+         // -------
+
+         this.getStatuses = function(sha, cb) {
+            _request('GET', repoPath + '/statuses/' + sha, null, function(err, heads, xhr) {
+               if (err) {
+                  return cb(err);
+               }
+               cb(null, heads, xhr);
+            })
+         };
+
          // Retrieve the tree a commit points to
          // -------
 

--- a/test/test.repo.js
+++ b/test/test.repo.js
@@ -97,6 +97,16 @@ describe('Github.Repository', function() {
       });
    });
 
+   it('should get statuses for a SHA from a repo', function(done) {
+      repo.getStatuses('20fcff9129005d14cc97b9d59b8a3d37f4fb633b', function(err, statuses) {
+         statuses.length.should.equal(6)
+         statuses.every(function(status) {
+            return status.url === 'https://api.github.com/repos/michael/github/statuses/20fcff9129005d14cc97b9d59b8a3d37f4fb633b'
+         }).should.equal(true);
+         done();
+      });
+   });
+
    it('should get a SHA from a repo', function(done) {
       repo.getSha('master', '.gitignore', function(err, sha) {
          should.not.exist(err);


### PR DESCRIPTION
Adds the Repo endpoint for `https://api.github.com/repos/<user>/<repo>/statuses/<sha>`


edit: Build is failing but this seems unrelated - 

```
npm ERR! phantomjs2@2.0.0 install: `node install.js`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the phantomjs2@2.0.0 install script 'node install.js'.```