### PR TITLE
When getting all pages, if the API response is an object, wrap it in an array before pushing it to results.

### DIFF
--- a/github.js
+++ b/github.js
@@ -121,8 +121,8 @@
                   return cb(err);
                }
 
-               if (Object.prototype.toString.call(res) === '[object Object]') {
-                  res = [ res ];
+               if (!(res instanceof Array)) {
+                  res = [res];
                }
 
                results.push.apply(results, res);

--- a/github.js
+++ b/github.js
@@ -121,6 +121,10 @@
                   return cb(err);
                }
 
+               if (Object.prototype.toString.call(res) === '[object Object]') {
+                  res = [ res ];
+               }
+
                results.push.apply(results, res);
 
                var next = (xhr.getResponseHeader('link') || '')


### PR DESCRIPTION
Fixes #267.