### PR TITLE
remove encodeURIComponent in b64encode

### DIFF
--- a/github.js
+++ b/github.js
@@ -25,7 +25,7 @@
       }
    } else {
       var b64encode = function(str) {
-         return root.btoa(encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, function(match, p1) {
+         return root.btoa(str.replace(/%([0-9A-F]{2})/g, function(match, p1) {
             return String.fromCharCode('0x' + p1);
          }));
       };


### PR DESCRIPTION
use encodeURIComponent in b64encode will get an error result when str is binary data