### PR TITLE
merge pull request

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,23 @@ var pullRequestID = 123;
 repo.getPull(pullRequestID, function(err, pullRequestInfo) {});
 ```
 
+Merge a Pull Request.
+
+```js
+var pullRequestID = 123;
+
+repo.mergePull({
+   number: pullRequestID,
+   // pull request head sha is required to merge a pull request safely
+   sha: 'f4c3e6d8045ea567cccdc0802e1769a85c6b690c'
+}, optionalMessage, function(err, mergeResult){});
+
+// or simply:
+repo.getPull(pullRequestID, function(err, pullRequestInfo) {
+   repo.mergePull(pullRequestInfo, function(err, mergeResult){});
+});
+```
+
 Create Pull Request.
 
 ```js

--- a/src/github.js
+++ b/src/github.js
@@ -458,6 +458,23 @@
             _request('GET', repoPath + '/pulls/' + number, null, cb);
          };
 
+         // Merge a specific pull request
+         // -------
+
+         this.mergePull = function(pull, message, cb) {
+            if (typeof message === 'function') {
+               cb = message;
+               message = '';
+            }
+
+            var data = {
+               sha: pull.sha || pull.head.sha,
+               commit_message: message
+            };
+
+            _request('PUT', repoPath + '/pulls/' + pull.number + '/merge', data, cb);
+         };
+
          // Retrieve the changes made between base and head
          // -------
 

--- a/test/test.repo.js
+++ b/test/test.repo.js
@@ -33,6 +33,7 @@ if (typeof window === 'undefined') { // We're in NodeJS
       // jscs:disable
       imageB64 = 'iVBORw0KGgoAAAANSUhEUgAAACsAAAAmCAAAAAB4qD3CAAABgElEQVQ4y9XUsUocURQGYN/pAyMWBhGtrEIMiFiooGuVIoYsSBAsRSQvYGFWC4uFhUBYsilXLERQsDA20YAguIbo5PQp3F3inVFTheSvZoavGO79z+mJP0/Pv2nPtlfLpfLq9tljNquO62S8mj1kmy/8nrHm/Xaz1930bt5n1+SzVmyrilItsod9ON0td1V59xR9hwV2HsMRsbfROLo4amzsRcQw5vO2CZPJEU5CM2cXYTCxg7CY2mwIVhK7AkNZYg9g4CqxVwNwkNg6zOTKMQP1xFZgKWeXoJLYdSjl7BysJ7YBIzk7Ap8TewLOE3oOTtIz6y/64bfQn55ZTIAPd2gNTOTurcbzp7z50v1y/Pq2Q7Wczca8vFjG6LvbMo92hiPL96xO+eYVPkVExMdONetFXZ+l+eP9cuV7RER8a9PZwrloTXv2tfv285ZOt4rnrTXlydxCu9sZmGrdN8eXC3ATERHXsHD5wC7ZL3HdsaX9R3bUzlb7YWvn/9ipf93+An8cHsx3W3WHAAAAAElFTkSuQmCC';
       imageBlob = new Blob();
+
       // jscs:enable
    }
 }
@@ -422,6 +423,42 @@ describe('Creating new Github.Repository', function() {
 
          // @TODO write better assertion
          done();
+      });
+   });
+
+   it('should merge pull requests on repo', function(done) {
+
+      var baseBranch = 'master';
+      var headBranch = 'pull-request';
+      var pullRequestTitle = 'Test pull request';
+      var pullRequestBody = 'This is a test pull request to be merged';
+
+      repo.branch(baseBranch, headBranch, function() {
+         repo.write(headBranch, 'TEST.md', 'THIS IS AN UPDATED TEST THAT WILL GET MERGED', 'Updating test', function() {
+            repo.createPullRequest(
+               {
+                  title: pullRequestTitle,
+                  body: pullRequestBody,
+                  base: baseBranch,
+                  head: headBranch
+               },
+               function(err, pullRequest, xhr) {
+                  should.not.exist(err);
+                  xhr.should.be.instanceof(XMLHttpRequest);
+
+                  repo.mergePull(pullRequest, function(err, mergedPullRequest, xhr) {
+                     should.not.exist(err);
+                     xhr.should.be.instanceof(XMLHttpRequest);
+
+                     should.exist(mergedPullRequest.sha);
+                     should(mergedPullRequest.merged).equal(true);
+                     should.exist(mergedPullRequest.message);
+
+                     done();
+                  });
+               }
+            );
+         });
       });
    });
 


### PR DESCRIPTION
adding `repo.mergePull`
docs: https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button

note the unit test isn't really testing a succesful merge (but a failture to merge), given the destructive nature of that action I think that would require mocking of the github API, but that might be a big effort.

ps: this is a pull request to merge pull requests :open_mouth: