### PR TITLE
Support for /user/repos with visibility and/or affiliation query.

### DIFF
--- a/lib/Requestable.js
+++ b/lib/Requestable.js
@@ -91,7 +91,9 @@ class Requestable {
     * @return - the options to pass to the request
     */
    _getOptionsWithDefaults(requestOptions = {}) {
-      requestOptions.type = requestOptions.type || 'all';
+      if (!(requestOptions.visibility || requestOptions.affiliation)) {
+         requestOptions.type = requestOptions.type || 'all';
+      }
       requestOptions.sort = requestOptions.sort || 'updated';
       requestOptions.per_page = requestOptions.per_page || '100'; // jscs:ignore
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-api",
-  "version": "1.3.1",
+  "version": "1.3.0",
   "license": "BSD-3-Clause-Clear",
   "description": "A higher-level wrapper around the Github API.",
   "main": "dist/components/GitHub.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-api",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "BSD-3-Clause-Clear",
   "description": "A higher-level wrapper around the Github API.",
   "main": "dist/components/GitHub.js",


### PR DESCRIPTION
/user/repos supports "visibility" and "affiliation" parameters which are not compatible with "type". Not adding a default type if the user provides either of these. see: https://developer.github.com/v3/repos/#list-user-repositories 