### PR TITLE
Added getReadme to Repository

### DIFF
--- a/lib/Repository.js
+++ b/lib/Repository.js
@@ -405,6 +405,20 @@ class Repository extends Requestable {
    }
 
    /**
+    * Get the README of a repository
+    * @see https://developer.github.com/v3/repos/contents/#get-the-readme
+    * @param {string} ref - the ref to check
+    * @param {boolean} raw - `true` if the results should be returned raw instead of GitHub's normalized format
+    * @param {Function} cb - will receive the fetched data
+    * @return {Promise} - the promise for the http request
+    */
+   getReadme(ref, raw, cb) {
+      return this._request('GET', `/repos/${this.__fullname}/readme`, {
+         ref
+      }, cb, raw);
+   }
+
+   /**
     * Fork a repository
     * @see https://developer.github.com/v3/repos/forks/#create-a-fork
     * @param {Function} cb - will receive the information about the newly created fork

--- a/test/repository.spec.js
+++ b/test/repository.spec.js
@@ -75,6 +75,14 @@ describe('Repository', function() {
          }));
       });
 
+      it('should show repo readme', function(done) {
+         remoteRepo.getReadme('master', 'raw', assertSuccessful(done, function(err, text) {
+            expect(text).to.contain('# Github.js');
+
+            done();
+         }));
+      });
+
       it('should get ref from repo', function(done) {
          remoteRepo.getRef('heads/master', assertSuccessful(done));
       });


### PR DESCRIPTION
Derived from the very similar getContents. Provides support for the
preferred method of retrieving the README from a repository.