### PR TITLE
add getBranch to repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ docs/
 dist/
 coverage/
 node_modules/
+.idea/
 
 .DS_Store
 npm-debug.log

--- a/lib/Repository.js
+++ b/lib/Repository.js
@@ -153,6 +153,17 @@ class Repository extends Requestable {
    }
 
    /**
+    * Get a single branch
+    * @see https://developer.github.com/v3/repos/branches/#get-branch
+    * @param {string} branch - the name of the branch to fetch
+    * @param {Requestable.callback} cb - will receive the branch from the API
+    * @returns {Promise} - the promise for the http request
+    */
+   getBranch(branch, cb) {
+      return this._request('GET', `/repos/${this.__fullname}/branches/${branch}`, null, cb, 'raw');
+   }
+
+   /**
     * Get a commit from the repository
     * @see https://developer.github.com/v3/repos/commits/#get-a-single-commit
     * @param {string} sha - the sha for the commit to fetch

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint": "gulp lint",
     "make-docs": "node_modules/.bin/jsdoc -c .jsdoc.json --verbose",
     "release": "./release.sh",
-    "install": "npm run build"
+    "install": "npm i && npm run build"
   },
   "babel": {
     "presets": [

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "test-verbose": "DEBUG=github* npm test",
     "lint": "gulp lint",
     "make-docs": "node_modules/.bin/jsdoc -c .jsdoc.json --verbose",
-    "release": "./release.sh",
-    "install": "npm i && npm run build"
+    "release": "./release.sh"
   },
   "babel": {
     "presets": [

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test-verbose": "DEBUG=github* npm test",
     "lint": "gulp lint",
     "make-docs": "node_modules/.bin/jsdoc -c .jsdoc.json --verbose",
-    "release": "./release.sh"
+    "release": "./release.sh",
+    "install": "npm run build"
   },
   "babel": {
     "presets": [

--- a/test/repository.spec.js
+++ b/test/repository.spec.js
@@ -52,6 +52,14 @@ describe('Repository', function() {
          }));
       });
 
+      it('should get a branch', function(done) {
+         remoteRepo.getBranch('master', assertSuccessful(done, function(err, content) {
+            expect(content.name).to.be('master');
+
+            done();
+         }));
+      });
+
       it('should show repo contents', function(done) {
          remoteRepo.getContents('master', '', false, assertSuccessful(done, function(err, contents) {
             expect(contents).to.be.an.array();


### PR DESCRIPTION
This method is present on Github, and provides a lot more detail about a particular branch than `listBranches`