### PR TITLE
Change array response data type check

### DIFF
--- a/lib/Requestable.js
+++ b/lib/Requestable.js
@@ -228,9 +228,9 @@ class Requestable {
       return this._request('GET', path, options)
          .then((response) => {
             let thisGroup;
-            if (response.data instanceof Array) {
+            if (response.data && typeof response.data.push === 'function') {
                thisGroup = response.data;
-            } else if (response.data.items instanceof Array) {
+            } else if (response.data.items && typeof response.data.items.push === 'function') {
                thisGroup = response.data.items;
             } else {
                let message = `cannot figure out how to append ${response.data} to the result set`;


### PR DESCRIPTION
Hi,

I tested this library using [jest] + [nock], but I got an error with error message:

```
Error: cannot figure out how to append [object Object] to the result set
        at ResponseError.Error (native)
        at new ResponseError (/Users/ngs/.go/src/github.com/ngs/wiplock/node_modules/github-api/dist/components/Requestable.js:103:92)
        at /Users/ngs/.go/src/github.com/ngs/wiplock/node_modules/github-api/dist/components/Requestable.js:276:25
        at run (/Users/ngs/.go/src/github.com/ngs/wiplock/node_modules/core-js/modules/es6.promise.js:87:22)
        at /Users/ngs/.go/src/github.com/ngs/wiplock/node_modules/core-js/modules/es6.promise.js:100:28
        at flush (/Users/ngs/.go/src/github.com/ngs/wiplock/node_modules/core-js/modules/_microtask.js:18:9)
        at process._tickCallback (internal/process/next_tick.js:103:7)
```

and I found this comparison was returned `false`

```
response.data instanceof Array
```

https://github.com/michael/github/blob/master/lib/Requestable.js#L231

So I changed this to check the `data` has `push` method.

[jest]: https://facebook.github.io/jest/
[nock]: https://github.com/node-nock/nock